### PR TITLE
Add source timezone parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ or, specify a timezone:
 {{ dbt_extend.to_local_tz('my_column', 'America/New_York') }}
 ```
 
+or, also specify a source timezone:
+
+```python
+{{ dbt_extend.to_local_tz('my_column', 'America/New_York', 'UTC') }}
+```
+
+Using named parameters, we can also specify the source only and rely on the configuration parameter for the target:
+
+```python
+{{ dbt_extend.to_local_tz('my_column', source_tz='UTC') }}
+```
+
 
 #### yesterday ([source](macros/date/yesterday.sql))
 Gets yesterday's date, based on local date.

--- a/macros/date/to_local_tz.sql
+++ b/macros/date/to_local_tz.sql
@@ -1,4 +1,8 @@
-{%- macro to_local_tz(column, tz=None) -%}
-{% set tz = var("dbt_extend:time_zone") if not tz else tz %}
-convert_timezone('{{ tz }}', {{ column }})::{{dbt_utils.type_timestamp()}}
+{%- macro to_local_tz(column, target_tz=None, source_tz=None) -%}
+{%- set target_tz = var("dbt_extend:time_zone") if not target_tz else target_tz -%}
+{%- if not source_tz -%}
+convert_timezone('{{ target_tz }}', {{ column }})::{{ dbt_utils.type_timestamp() }}
+{%- else -%}
+convert_timezone('{{ source_tz }}', '{{ target_tz }}', {{ column }})::{{ dbt_utils.type_timestamp() }}
+{%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
This PR adds an optional parameter to let users specify a source timezone, in the case where a timestamp does not have a timezone.

For example:
```python
{{ dbt_extend.to_local_tz('my_column', 'America/New_York', 'UTC') }}
```

Using named parameters, we can also specify the source only and rely on the configuration parameter for the target:

```python
{{ dbt_extend.to_local_tz('my_column', source_tz='UTC') }}
```
