### PR TITLE
Use package syntax for utils depedency

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - git: "https://github.com/fishtown-analytics/dbt-utils"
-    revision: 0.2.0
+  - package: fishtown-analytics/dbt_utils
+    version: [">=0.2.0", "<0.3.0"]


### PR DESCRIPTION
By using the package syntax, dbt is able to resolve shared dependencies.

```
$ cat packages.yml
packages:
  - git: "https://github.com/calogica/dbt-extend.git" # install from main repo
    revision: 0.1.2
  - package: fishtown-analytics/redshift
    version: 0.2.1
  - package: fishtown-analytics/logging
    version: 0.1.6

$ dbt clean && dbt deps
Running with dbt=0.14.0
Checking target/*
 Cleaned target/*
Checking dbt_modules/*
 Cleaned dbt_modules/*
Checking logs/*
 Cleaned logs/*
Finished cleaning all paths.
Running with dbt=0.14.0
Encountered an error:
Found duplicate project dbt_utils. This occurs when a dependency has the same project name as some other dependency.

$ cat packages.yml
packages:
  - git: "https://github.com/clrcrl/dbt-extend.git"
    revision: "fix/use-package-syntax" # install from this branch
  - package: fishtown-analytics/redshift
    version: 0.2.1
  - package: fishtown-analytics/logging
    version: 0.1.6

$ dbt clean && dbt deps
Running with dbt=0.14.0
Checking target/*
 Cleaned target/*
Checking dbt_modules/*
 Cleaned dbt_modules/*
Checking logs/*
 Cleaned logs/*
Finished cleaning all paths.
Running with dbt=0.14.0
Installing https://github.com/clrcrl/dbt-extend.git@fix/use-package-syntax
  Installed from revision fix/use-package-syntax

Installing fishtown-analytics/redshift@=0.2.1
  Installed from version 0.2.1

Installing fishtown-analytics/logging@=0.1.6
  Installed from version 0.1.6

Installing fishtown-analytics/dbt_utils@=0.2.1
  Installed from version 0.2.1
```